### PR TITLE
Add interactive map

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,6 +4,8 @@ layout: default
 
 ![Map with points for a recent run of the scrapers](images/overview-map.png)
 
+[Browse the map](map/)
+
 ## Data Downloads
 
 Downloads of the results from all the scrapers:

--- a/map/index.html
+++ b/map/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">
+
+<title>All The Places | Map</title>
+
+<style>
+  body { margin: 0; padding: 0; }
+  #map { position: absolute; top: 0; bottom: 0; width: 100%; }
+
+  .places-popup { max-height: 40vh; }
+  .places-popup > div { overflow: auto; }
+  .places-popup pre { white-space: pre-wrap; }
+</style>
+
+<script
+  src="https://unpkg.com/maplibre-gl@2.1.7/dist/maplibre-gl.js"
+  crossorigin integrity="sha512-gbL8519AKjxUDt2MQkH9X43fFWl34kv6uXVBJVj/0+QbIAOBDBCN8R3Z5GBgGuFoU3JH+t8btwF7gPK2/Y2Hvw=="
+></script>
+
+<link
+  href="https://unpkg.com/maplibre-gl@2.1.7/dist/maplibre-gl.css"
+  rel="stylesheet"
+  crossorigin integrity="sha512-3rG/XrR5du72D9zrz70tH4kRl8DBGWt9TabqBPxncxZxw87kn07qz86wkDd23cvuqSUiXw+larY8C4GO5wjrIw=="
+/>
+
+<script type="module" src="viewer.js"></script>
+
+<div id="map"></div>
+

--- a/map/style.json
+++ b/map/style.json
@@ -1,0 +1,94 @@
+{
+  "version": 8,
+  "glyphs": "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
+  "sources": {
+    "alltheplaces": {
+      "url": "https://all-the-places-338115.web.app/services/output",
+      "type": "vector"
+    },
+    "raster-tiles": {
+      "type": "raster",
+      "tiles": [
+        "https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}{ratio}.png",
+        "https://cartodb-basemaps-b.global.ssl.fastly.net/light_all/{z}/{x}/{y}{ratio}.png",
+        "https://cartodb-basemaps-c.global.ssl.fastly.net/light_all/{z}/{x}/{y}{ratio}.png",
+        "https://cartodb-basemaps-d.global.ssl.fastly.net/light_all/{z}/{x}/{y}{ratio}.png"
+      ],
+      "tileSize": 256,
+      "attribution": "© <a href=\"http://www.openstreetmap.org/copyright\"> OpenStreetMap </a> contributors, © <a href=\"https://carto.com/about-carto/\"> CARTO </a>"
+    }
+  },
+  "layers": [
+    {
+      "id": "tiles",
+      "type": "raster",
+      "source": "raster-tiles"
+    },
+    {
+      "id": "output",
+      "type": "circle",
+      "source": "alltheplaces",
+      "source-layer": "alltheplaces",
+      "paint": {
+        "circle-radius": [
+          "interpolate",
+          [
+            "exponential",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          0,
+          2,
+          10,
+          ["*",
+            6,
+            [
+              "number",
+              [
+                "get",
+                "sqrt_point_count"
+              ],
+              1
+            ]
+          ],
+          14,
+          10,
+          22,
+          50
+        ],
+        "circle-color": [
+          "case",
+          [
+            "boolean",
+            [
+              "get",
+              "clustered"
+            ],
+            false
+          ],
+          "rgba(128,0,255,0.7)",
+          "rgba(255,128,0,0.7)"
+        ]
+      }
+    },
+    {
+      "id": "output-text",
+      "type": "symbol",
+      "source": "alltheplaces",
+      "source-layer": "alltheplaces",
+      "minzoom": 11,
+      "layout": {
+        "text-field": [
+          "get",
+          "@spider"
+        ],
+        "text-font": [
+          "Metropolis Regular"
+        ],
+        "text-size": 10
+      }
+    }
+  ]
+}

--- a/map/viewer.js
+++ b/map/viewer.js
@@ -1,0 +1,105 @@
+export const map = (window.map = new maplibregl.Map({
+  container: "map",
+  style: "./style.json",
+  center: [0, 0],
+  zoom: 1,
+  hash: true,
+}));
+map.addControl(new maplibregl.ScaleControl());
+map.dragRotate.disable();
+map.touchZoomRotate.disableRotation();
+map.touchPitch.disable();
+map.keyboard.disableRotation();
+map.getCanvas().focus();
+
+map.on("click", "output", (e) => {
+  const cluster = e.features.find((x) => x.properties.clustered);
+  if (cluster) {
+    map.easeTo({
+      center: cluster.geometry.coordinates,
+      zoom: 1 + map.getZoom(),
+    });
+  } else {
+    const popupContents = document.createElement("div");
+    for (let i = 0; i < e.features.length; i++) {
+      const feature = e.features[i];
+      popupContents.append(renderFeature(feature));
+      if (i + 1 < e.features.length) {
+        popupContents.append(document.createElement("hr"));
+      }
+    }
+
+    var popup = new maplibregl.Popup({
+      className: "places-popup",
+      maxWidth: "80%",
+    })
+      .setLngLat(e.lngLat)
+      .setDOMContent(popupContents)
+      .addTo(map);
+
+    popup.once("close", () => map.getCanvas().focus());
+
+    const first = e.features[0];
+    map.easeTo({
+      center: first.geometry.coordinates,
+    });
+  }
+});
+
+map.on("mouseenter", "output", function () {
+  map.getCanvas().style.cursor = "pointer";
+});
+
+map.on("mouseleave", "output", function () {
+  map.getCanvas().style.cursor = "";
+});
+
+function renderFeature(feature) {
+  const [x, y] = feature.geometry.coordinates.map((p) => +p.toFixed(6));
+  const props = Object.entries(feature.properties);
+  props.sort((a, b) => a[0].localeCompare(b[0]));
+  const formatValue = (k, v) => {
+    switch (k) {
+      case "website": {
+        const a = document.createElement("a");
+        a.target = "_blank";
+        a.href = a.textContent = v;
+        return a;
+      }
+      case "brand:wikidata": {
+        const a = document.createElement("a");
+        a.target = "_blank";
+        a.href = `https://www.wikidata.org/wiki/${v}`;
+        a.textContent = v;
+        return a;
+      }
+      case "@spider": {
+        const a = document.createElement("a");
+        a.target = "_blank";
+        const u = new URL(
+          "https://github.com/alltheplaces/alltheplaces/search"
+        );
+        u.searchParams.set("q", `path:locations/spiders "name ${v}"`);
+        a.href = u;
+        a.textContent = v;
+        return a;
+      }
+      default:
+        return v;
+    }
+  };
+  const e = document.createElement("pre");
+  const coord = document.createElement("a");
+  coord.target = "_blank";
+  coord.href = `https://www.openstreetmap.org/?mlat=${y}&mlon=${x}`;
+  coord.textContent = `${x},${y}`;
+  e.append(coord, "\n");
+  for (let i = 0; i < props.length; i++) {
+    const [k, v] = props[i];
+    e.append(k, "=", formatValue(k, v));
+    if (i + 1 < props.length) {
+      e.append("\n");
+    }
+  }
+  return e;
+}


### PR DESCRIPTION
So, this has been a small project of mine, tweaking the tippecanoe
invocation, making the data browser look nice, and implementing an
automatic build in google cloud. I've reached a point where I'm happy
with all of those facets.

High level things to be aware of here:

- Tippecanoe is invoked to automatically cluster so that the tile fits
  within the compressed byte size and/or number of features. However,
  the maximum zoom level must then be chosen manually (here, it's z11).
  This likely to be sufficient for a very long time, but if the limit is
  exceeded then the maximum zoom will include clustered points and the
  frontend will not work correctly as it assumes that zooming in will
  cause clusters to dissolve.

- Data browser could conceivably use a heatmap layer, but the clustered
  points render quickly enough that it's fine showing distinct circles.
  The map stutters slightly when zooming into Manhattan but that's
  entirely caused by too much text, not the circles.

- I am hosting this myself in Google Cloud, and it can probably stay
  that way if the bandwidth is acceptable. Server code is at
  https://github.com/jleedev/alltheplaces-serve