### PR TITLE
refresh builds.html with DataTables love

### DIFF
--- a/builds.html
+++ b/builds.html
@@ -5,28 +5,87 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.datatables.net/fixedcolumns/4.1.0/css/fixedColumns.dataTables.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
 
-    <title>All the Places Builds</title>
+    <title>ATP Builds</title>
+    <style>
+        body {
+            font-size: 12px;
+            padding: 10px 100px;
+        }
+    </style>
 </head>
 <body>
-<div class="container">
-    <h1>All the Places Builds</h1>
+    <table id="spider-table" class="display" style="width:100%"></table>
 
-    <table id="build-table" class="table">
-        <tr>
-            <th>Start Time</th>
-            <th>Build ID</th>
-            <th>Spider Count</th>
-            <th>Feature Count</th>
-            <th>Download</th>
-        </tr>
-    </table>
-
-</div>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.6/dist/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
-<script>
+<script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.datatables.net/fixedcolumns/4.1.0/js/dataTables.fixedColumns.min.js" crossorigin="anonymous"></script>
+
+    <script type=module>
+
+    // Return a list of history entries, sorted by most recent first.
+    async function fetchHistoryList() {
+        // The default configuration is the direct ATP history.json
+        let my_histories = [
+            {
+                "name": "ATP",
+                "url": "https://data.alltheplaces.xyz/runs/history.json",
+            },
+        ]
+        try {
+            // Try and load a config.json file from the serving context. If present then this
+            // will override the default configuration above.
+            const response = await window.fetch('./config.json')
+            if (response.status === 200) {
+                let json_response = await response.json()
+                my_histories = json_response["histories"]
+            }
+        } catch (error) {
+            // We catch the exception and proceed here as it enables the HTML to be used by the browser
+            // on the local file system without crashing out. Handy for development sometimes.
+            console.error(error)
+        }
+        let history_runs = []
+        for (let i = 0; i < my_histories.length; i++) {
+            // Now for each history list go and retrieve the full list and filter down to those with
+            // an "insights" URL.
+            let history_response = await window.fetch(my_histories[i].url)
+            if (history_response.status === 200) {
+                let history_json_response = await history_response.json()
+                for (let j = 0; j < history_json_response.length; j++) {
+                    let run_data = history_json_response[j]
+                    // It's better that URLs in the JSON are relative as that helps when we
+                    // may need to move things around etc, so cope with it.
+                    for (const field of ["insights_url", "output_url", "stats_url"]) {
+                        if (field in run_data) {
+                            // Make URL absolute with respect to serving history.json
+                            if (!run_data[field].startsWith("http")) {
+                                run_data[field] = new URL(run_data[field], history_response.url).toString()
+                            }
+                        }
+                    }
+                    // It's good to create expected fields in the JSON, some old runs did not have these!
+                    for (const field of ["size_bytes", "spiders", "stats_url", "total_lines"]) {
+                        if (! (field in run_data)) {
+                            run_data[field] = null
+                        }
+                    }
+                    run_data["name"] = run_data["start_time"].replace(/T.*$/,"") + " (" + my_histories[i].name + ")"
+                    history_runs.push(run_data)
+                }
+            }
+        }
+        // Sort into most recent first order.
+        history_runs.sort((a, b) => (a["run_id"] < b["run_id"]) ? 1 : ((b["run_id"] < a["run_id"]) ? -1 : 0))
+        return history_runs
+    }
+
+    const data = await fetchHistoryList();
+
     function formatBytes(bytes, decimals = 2) {
         if (bytes === 0) return '0 Bytes';
 
@@ -39,25 +98,71 @@
         return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
     }
 
-    $.getJSON("https://data.alltheplaces.xyz/runs/history.json", function (data) {
-        data.sort(function (a, b) {
-            if (a.start_time < b.start_time) {
-                return 1;
-            } else {
-                return -1;
-            }
-        }).forEach(function (build) {
-            $("#build-table").append(
-                $("<tr>").append(
-                    $("<td>").append(build.start_time),
-                    $("<td>").append($("<a>").attr("href", build.stats_url).append(build.run_id)),
-                    $("<td>").append(Number(build.spiders).toLocaleString()),
-                    $("<td>").append(Number(build.total_lines).toLocaleString()),
-                    $("<td>").append($("<a>").attr("href", build.output_url).append("Download " + formatBytes(build.size_bytes, 1))),
-                )
-            );
-        });
+    // Render with datatable
+    let dataTable = $("#spider-table").DataTable({
+        data,
+        lengthMenu: [
+            [10, 15, 20, 25, 50, 75, 100, -1],
+            [10, 15, 20, 25, 50, 75, 100, "All"],
+        ],
+        pageLength: 15,
+        order: [[0, 'desc']],
+        columns: [
+            {"title": "Run", "data": "name"},
+            {
+                "title": "Run statistics",
+                "data": "stats_url",
+                "render": function (data, type, row, meta) {
+                    if (type === 'display') {
+                        if (data) {
+                            return '<a href="' + data + '">Summary</a>'
+                        }
+                        return ""
+                    }
+                    return data;
+                }
+            },
+            {
+                "title": "Spider count",
+                "data": "spiders",
+                "render": function (data, type, row, meta) {
+                    if (type === 'display' && data) {
+                        data = data.toLocaleString("us-US")
+                    }
+                    return data;
+                }
+            },
+            {
+                "title": "Feature count",
+                "data": "total_lines",
+                "render": function (data, type, row, meta) {
+                    if (type === 'display' && data) {
+                        data = data.toLocaleString("us-US")
+                    }
+                    return data;
+                }
+            },
+            {
+                "title": "Download features",
+                "data": "size_bytes",
+                "render": function (data, type, row, meta) {
+                    if (type === 'display') {
+                        if (data && (data > 0)) {
+                            let text = "Download " + formatBytes(data)
+                            return '<a href="' + row["output_url"] + '">' + text + '</a>'
+                        }
+                        return ""
+                    }
+                    return data;
+                }
+            },
+        ],
+        columnDefs: [
+            { className: 'dt-center', targets: [1,4] },
+            { className: 'dt-right', targets: [2,3] },
+        ],
     });
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
I've given builds.html a bit of (DataTables) love. It's accessing the history via the same mechanism as the recent update to wikidata.html, with a few upgrades to fix up fields that were not there historically so the DataTables code does not complain.

I still want to get around to doing work on spiders.html. At that point I'll pull out the JS for accessing the history and perhaps a few other utility functions in a shared file? Should thin things down a little bit.
