### PR TITLE
Revamp the spiders.html stability calculation

### DIFF
--- a/builds.html
+++ b/builds.html
@@ -17,7 +17,17 @@
     </style>
 </head>
 <body>
-    <table id="spider-table" class="display" style="width:100%"></table>
+    <table id="spider-table" class="display" style="width:100%">
+        <tfoot>
+        <tr>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+        </tr>
+        </tfoot>
+    </table>
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.6/dist/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
@@ -105,6 +115,21 @@
             { className: 'dt-center', targets: [1,4] },
             { className: 'dt-right', targets: [2,3] },
         ],
+        "footerCallback": function (row, data, start, end, display) {
+            let api = this.api()
+            // Total up the numeric columns (all next to each)
+            let columns = [3]
+            for (let i in columns) {
+                let total = api
+                    .column(columns[i], {filter: "applied"})
+                    .data()
+                    .reduce(function (a, b) {
+                        return a + b;
+                    }, 0);
+                // Update total in footer
+                $(api.column(columns[i]).footer()).html(total.toLocaleString("us-US"));
+            }
+        },
     });
 
 </script>

--- a/spiders.html
+++ b/spiders.html
@@ -80,13 +80,49 @@
     <script type=module>
 
     function getColorGradient(percentage) {
-        let red = (percentage > 50 ? 1 - 2 * (percentage - 50) / 100.0 : 1.0) * 255;
-        let green = (percentage > 50 ? 1.0 : 2 * percentage / 100.0) * 255;
+        if (percentage > 98) {
+            // Don't mess around with colour gradients for "obviously" good.
+            return "rgb(0,255,0)";
+        }
+        else if (percentage < 70) {
+            // Don't mess around with colour gradients for "obviously" bad.
+            return "rgb(255,0,0)";
+        }
+        // We give the inbetween scenario a colour gradient.
+        let inflection = 90
+        let red = (percentage > inflection ? 1 - 2 * (percentage - inflection) / 100.0 : 1.0) * 255;
+        let green = (percentage > inflection ? 1.0 : 2 * percentage / 100.0) * 255;
         return "rgb(" + red + "," + green + ",0)";
     }
 
     let NUM_BUILDS = 5; // Maximum number of builds to display.
-    let MAX_STABILITY = 500;  // Don't grade a standard deviation any more than this.
+
+    function calculateStability(row) {
+        // Normalise the POI count data such that each run outputs the same maximum number.
+        let NORMALISED_MAX_POIS = 10000.0
+        let maxFeatures = 0;
+        for (let i = 2; i <= NUM_BUILDS + 1; i++) {
+            if (row[i] > maxFeatures) {
+                maxFeatures = row[i]
+            }
+        }
+        if (maxFeatures > 0) {
+            let multiplier = NORMALISED_MAX_POIS / maxFeatures;
+            let sumSqDeviations = 0;
+            let runCount = 0;
+            // Calculate the variance from the MAXIMUM value for each (normalised count) run that occurred.
+            for (let i = 2; i <= NUM_BUILDS + 1; i++) {
+                if (row[i] != null) {
+                    let dev = NORMALISED_MAX_POIS - (multiplier * row[i]);
+                    sumSqDeviations += (dev * dev);
+                    runCount++;
+                }
+            }
+            const stDev = Math.sqrt(sumSqDeviations / runCount);
+            // Set a stability number from 0 to 100.
+            row[1] = 100 - ((Math.min(stDev, NORMALISED_MAX_POIS) / NORMALISED_MAX_POIS) * 100);
+        }
+    }
 
     // Fetch the stats JSON for a particular run.
     async function fetchStatsForHistoryListEntry(entry) {
@@ -122,46 +158,15 @@
     // Compute standard deviation and convert to flat tabular format.
     let data = [];
     Object.entries(buildsBySpider).forEach(entry => {
-
-        // Set spider name as the first entry in the row.
-        const row = [entry[0]];
-
-        // Only count builds which were run (i.e. have a numeric, possibly zero, entry).
-        let numValidBuilds = 0;
-        let sumFeatures = 0;
-
-        statsList.forEach(statsRun => {
-            let runName = statsRun["name"]
-            if (entry[1][runName]) {
-                numValidBuilds++;
-                sumFeatures += entry[1][runName].features;
-            }
-        })
-
-        const mean = (numValidBuilds === 0) ? 0 : (sumFeatures / numValidBuilds);
-        let sumSqDeviations = 0;
-        statsList.forEach(statsRun => {
-            let runName = statsRun["name"]
-            if (entry[1][runName]) {
-                let dev = entry[1][runName].features - mean;
-                sumSqDeviations += (dev * dev);
-            }
-        });
-        const variance = sumSqDeviations / numValidBuilds;
-        const stDev = Math.sqrt(variance);
-        if (sumFeatures > 0) {
-            const perc = 100 - ((Math.min(stDev, MAX_STABILITY) / MAX_STABILITY ) * 100);
-            row.push({stDev, perc});
-        } else {
-            row.push({stDev:null, perc:null});
-        }
-
+        // Set spider name as the first entry in the row, second entry is for the run stability calculation.
+        const row = [entry[0], null];
         // Now push the number of features in each run for this spider on to the row.
         statsList.forEach(statsRun => {
             let runName = statsRun["name"]
             row.push(entry[1][runName]?.features ?? null)
         })
-
+        // Calculate how "stable" we think the runs have been for this spider based on historical POI counts.
+        calculateStability(row)
         // Finally add the row to the data table
         data.push(row);
     });
@@ -189,10 +194,6 @@
             },
             {
                 title: "Stability",
-                data: {
-                    "sort": "1.stDev",
-                    "_": "1.perc",
-                },
                 createdCell(cell, cellData) {
                     const box = $("<div>").addClass("stability-box");
                     if (Number.isFinite(cellData)) {


### PR DESCRIPTION
Rather than calculate the variance of the run POI count from the mean I suggest it is better to calculate it from the maximum. This is on the basis that over a small period of time for most endpoints it is the more valid number to base a variance on. When performing the calculation I am also scaling each run count such the the maximum value POI count for each spider is the same (10,000).

On the display side I have adjusted the traffic light indicator to stop messing around with colour scaling for the "obviously" good and bad results.

I realise that this is more art than science so can only say that I feel the output is a bit more clear/useful than before! :-)
