### PR TITLE
Switch to the pmtiles source

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -13,15 +13,23 @@
   .places-popup pre { white-space: pre-wrap; }
 </style>
 
+<link rel=preload as=fetch href=style.json>
+<link rel=preload as=fetch crossorigin href="https://data.alltheplaces.xyz/runs/latest.json">
+
 <script
-  src="https://unpkg.com/maplibre-gl@2.1.7/dist/maplibre-gl.js"
-  crossorigin integrity="sha512-gbL8519AKjxUDt2MQkH9X43fFWl34kv6uXVBJVj/0+QbIAOBDBCN8R3Z5GBgGuFoU3JH+t8btwF7gPK2/Y2Hvw=="
+  src="https://unpkg.com/pmtiles@2.5.0/dist/index.js"
+  crossorigin integrity="sha512-O+12zmlTuWHTS3mMDjtPe02T/kX8XqRiI7k9i1BjsmuWyOjHfjQrlkLSwTRR+4Jg6LFMpLPk77rgnYRtscxjkw=="
+></script>
+
+<script
+  src="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.js"
+  crossorigin integrity="sha512-EzLsfPILfpJ/KP9ikfoPFBIoRaJryjaHHB4YHXAU9nfiQIttgk4F/FWsNht+2bBq7A+7Se9LbU0OZgJNVFmlOQ=="
 ></script>
 
 <link
-  href="https://unpkg.com/maplibre-gl@2.1.7/dist/maplibre-gl.css"
+  href="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.css"
   rel="stylesheet"
-  crossorigin integrity="sha512-3rG/XrR5du72D9zrz70tH4kRl8DBGWt9TabqBPxncxZxw87kn07qz86wkDd23cvuqSUiXw+larY8C4GO5wjrIw=="
+  crossorigin integrity="sha512-zFG1SdFAVbwb/egjQlLXkpfrFbSkzpt526xWJ41fIbY7/qpBk+WF+Wj/fA2If4AnMD3ukCjqaq1i+l1DelWUbA=="
 />
 
 <script type="module" src="viewer.js"></script>

--- a/map/style.json
+++ b/map/style.json
@@ -3,7 +3,7 @@
   "glyphs": "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
   "sources": {
     "alltheplaces": {
-      "url": "https://all-the-places-338115.web.app/services/output",
+      "url": null,
       "type": "vector"
     },
     "raster-tiles": {

--- a/map/viewer.js
+++ b/map/viewer.js
@@ -1,10 +1,18 @@
+const protocol = new pmtiles.Protocol();
+maplibregl.addProtocol("pmtiles", protocol.tile);
+
+const { pmtiles_url } = await fetch("https://data.alltheplaces.xyz/runs/latest.json").then(r => r.json());
+const style = await fetch("./style.json").then(r => r.json());
+style.sources.alltheplaces.url = `pmtiles://${pmtiles_url}`;
+
 export const map = (window.map = new maplibregl.Map({
   container: "map",
-  style: "./style.json",
+  style,
   center: [0, 0],
   zoom: 1,
   hash: true,
 }));
+
 map.addControl(new maplibregl.ScaleControl());
 map.dragRotate.disable();
 map.touchZoomRotate.disableRotation();


### PR DESCRIPTION
Requires configuring CORS on the data endpoint:

>     // ok
>     latest=await fetch("https://data.alltheplaces.xyz/runs/latest.json").then(r=>r.json());
>     // not allowed
>     x=await fetch(latest.pmtiles_url, {headers:{range:"bytes=0-65536"}});
> Access to fetch at 'https://data.alltheplaces.xyz/runs/2023-09-02-13-32-00/output.pmtiles' from origin 'https://www.alltheplaces.xyz' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

