### PR TITLE
Add URL Query parameters to the /spiders endpoint

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -1,5 +1,6 @@
-
-// Return a list of history entries, sorted by most recent first.
+/**
+ * Return a list of history entries, sorted by most recent first.
+ */
 async function fetchHistoryList() {
     // The default configuration is the direct ATP history.json
     let my_histories = [
@@ -54,4 +55,17 @@ async function fetchHistoryList() {
     // Sort into most recent first order.
     history_runs.sort((a, b) => (a["run_id"] < b["run_id"]) ? 1 : ((b["run_id"] < a["run_id"]) ? -1 : 0))
     return history_runs
+}
+
+/**
+ * Gets URL query parameters and loads values into corresponding form fields.
+ */
+function getUrlQueryParams() {
+    try {
+        const urlParams = new URLSearchParams(window.location.search);
+        return Object.fromEntries(urlParams.entries());
+    } catch (error) {
+        console.error(error);
+        return {};
+    }
 }

--- a/spiders.html
+++ b/spiders.html
@@ -95,6 +95,11 @@
         return "rgb(" + red + "," + green + ",0)";
     }
 
+    const LINK_FORMAT_OPTIONS = [
+        ['geojson', 'Feature GeoJSON'],
+        ['statistics', 'Spider stats JSON'],
+        ['logs', 'Spider error logs'],
+    ];
     let NUM_BUILDS = 5; // Maximum number of builds to display.
     const URL_QUERY_PARAMS = getUrlQueryParams();
 
@@ -173,7 +178,8 @@
     });
 
     // Default link format is Featire GeoJSON, the selector in the table header can change this.
-    let linkFormat = "geojson";
+    let linkFormat = LINK_FORMAT_OPTIONS[parseFloat(URL_QUERY_PARAMS?.['link_format']) - 1]?.[0];
+    linkFormat ||= "geojson";
     function onLinkFormatChange() {
         linkFormat = document.getElementById('format-select').value
         dataTable.draw("page")
@@ -267,8 +273,10 @@
         },
     });
 
-    $('div.selector-div').html('<label class="selector-label">Links give <select id="format-select" aria-controls="spider-table"><option value="geojson">Feature GeoJSON</option><option value="statistics">Spider stats JSON</option><option value="logs">Spider error logs</option></select></label>');
-    document.getElementById('format-select').onchange = onLinkFormatChange
+    const linkFormatOptionsHtml = LINK_FORMAT_OPTIONS.map(([val, label], i) => `<option value="${val}">${label}</option>`).join('');
+    $('div.selector-div').html(`<label class="selector-label">Links give <select id="format-select" aria-controls="spider-table">${linkFormatOptionsHtml}</select></label>`);
+    document.getElementById('format-select').value = linkFormat;
+    document.getElementById('format-select').onchange = onLinkFormatChange;
 
     </script>
 </body>

--- a/spiders.html
+++ b/spiders.html
@@ -179,7 +179,9 @@
     });
 
     // Default link format is Featire GeoJSON, the selector in the table header can change this.
-    let linkFormat = LINK_FORMAT_OPTIONS[parseFloat(URL_QUERY_PARAMS?.['link_format']) - 1]?.[0];
+    let linkFormat = Number.isFinite(parseFloat(URL_QUERY_PARAMS['link_format']))
+        ? LINK_FORMAT_OPTIONS[parseFloat(URL_QUERY_PARAMS['link_format']) - 1]?.[0]
+        : URL_QUERY_PARAMS['link_format']?.trim();
     linkFormat ||= "geojson";
     function onLinkFormatChange() {
         linkFormat = document.getElementById('format-select').value

--- a/spiders.html
+++ b/spiders.html
@@ -203,7 +203,7 @@
             {
                 title: "Spider",
                 createdCell(cell) {
-                    $(cell).html(`${cell.innerText}<a href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
+                    $(cell).html(`${cell.innerText}<a target="_blank" href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
                 }
             },
             {

--- a/spiders.html
+++ b/spiders.html
@@ -198,12 +198,12 @@
         pageLength: parseFloat(URL_QUERY_PARAMS['page_length']) || 10,
         dom: 'l<"selector-div">frtip',
         order: [[2, 'desc']],
-        search: { search: URL_QUERY_PARAMS?.search || '' },
+        search: { search: URL_QUERY_PARAMS['search'] || '' },
         columns: [
             {
                 title: "Spider",
                 createdCell(cell) {
-                    if (URL_QUERY_PARAMS?.['link_to_source_code'] === 'true') {
+                    if (URL_QUERY_PARAMS['link_to_source_code'] === 'true') {
                         $(cell).html(`${cell.innerText}<a href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
                     }
                 }

--- a/spiders.html
+++ b/spiders.html
@@ -96,6 +96,7 @@
     }
 
     let NUM_BUILDS = 5; // Maximum number of builds to display.
+    const URL_QUERY_PARAMS = getUrlQueryParams();
 
     function calculateStability(row) {
         // Normalise the POI count data such that each run outputs the same maximum number.
@@ -188,6 +189,7 @@
         pageLength: 10,
         dom: 'l<"selector-div">frtip',
         order: [[2, 'desc']],
+        search: { search: URL_QUERY_PARAMS?.search || '' },
         columns: [
             {
                 title: "Spider",

--- a/spiders.html
+++ b/spiders.html
@@ -40,7 +40,7 @@
             background-color: grey;
             position: relative;
             right: 0;
-            margin: auto; 
+            margin: auto;
         }
 
         .selector-label {
@@ -100,6 +100,7 @@
         ['statistics', 'Spider stats JSON'],
         ['logs', 'Spider error logs'],
     ];
+    const GITHUB_URL = "https://github.com/alltheplaces/alltheplaces/tree/master";
     let NUM_BUILDS = 5; // Maximum number of builds to display.
     const URL_QUERY_PARAMS = getUrlQueryParams();
 
@@ -145,14 +146,14 @@
     const statsList = await Promise.all(historyList.map(fetchStatsForHistoryListEntry))
 
     // Re-pivot the build data by spider.
-    let buildsBySpider = {};
+    const spiderToFilename = {};
+    const buildsBySpider = {};
     statsList.forEach(statsRun => {
         let runName = statsRun["name"]
         statsRun.results.forEach(spiderEntry => {
-            let spiderName = spiderEntry["spider"]
-            if (!buildsBySpider[spiderName]) {
-                buildsBySpider[spiderName] = {}
-            }
+            let spiderName = spiderEntry["spider"];
+            spiderToFilename[spiderName] = spiderEntry["filename"];
+            buildsBySpider[spiderName] ||= {}
             buildsBySpider[spiderName][runName] = {
                 errors: spiderEntry["errors"],
                 features: spiderEntry["features"],
@@ -199,6 +200,11 @@
         columns: [
             {
                 title: "Spider",
+                createdCell(cell) {
+                    if (URL_QUERY_PARAMS?.['link_to_source_code'] === 'true') {
+                        $(cell).html(`${cell.innerText}<a href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
+                    }
+                }
             },
             {
                 title: "Stability",

--- a/spiders.html
+++ b/spiders.html
@@ -203,9 +203,7 @@
             {
                 title: "Spider",
                 createdCell(cell) {
-                    if (URL_QUERY_PARAMS['link_to_source_code'] === 'true') {
-                        $(cell).html(`${cell.innerText}<a href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
-                    }
+                    $(cell).html(`${cell.innerText}<a href="${GITHUB_URL}/${spiderToFilename[cell.innerText]}">✎</a>`);
                 }
             },
             {

--- a/spiders.html
+++ b/spiders.html
@@ -186,7 +186,7 @@
             [10, 15, 20, 25, 50, 75, 100, -1],
             [10, 15, 20, 25, 50, 75, 100, "All"],
         ],
-        pageLength: 10,
+        pageLength: parseFloat(URL_QUERY_PARAMS['page_length']) || 10,
         dom: 'l<"selector-div">frtip',
         order: [[2, 'desc']],
         search: { search: URL_QUERY_PARAMS?.search || '' },


### PR DESCRIPTION
I've added the ability to read query parameters from the URL. For example:

```
https://www.alltheplaces.xyz/spiders.html?search=costco
```
<img width="853" alt="image" src="https://github.com/alltheplaces/alltheplaces.xyz/assets/76538249/d5aa717a-c5d2-49da-b93a-874db1ba8bda">

```
https://www.alltheplaces.xyz/spiders.html?link_format=2
```
<img width="860" alt="image" src="https://github.com/alltheplaces/alltheplaces.xyz/assets/76538249/9aee10c6-3fb4-4538-8631-75e9da689f23">

```
https://www.alltheplaces.xyz/spiders.html?link_format=1&search=ci&page_length=20
```
<img width="889" alt="image" src="https://github.com/alltheplaces/alltheplaces.xyz/assets/76538249/9f048f69-07be-426b-a13e-6d254c0dbe16">

I also added this easter egg: `link_to_source_code=true`. This adds a link next to each title of each spider that links back to their source code in the GitHub repo. I found this to be extremely useful when trying to figure out issues with particular spiders

<img width="895" alt="image" src="https://github.com/alltheplaces/alltheplaces.xyz/assets/76538249/740c07eb-4cf4-47cd-a45b-763fd447242b">
