### PR TITLE
Upgrade to DataTables 2

### DIFF
--- a/css/builds.css
+++ b/css/builds.css
@@ -1,5 +1,5 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
-@import "datatables.net-dt/css/jquery.dataTables.min.css";
+@import "datatables.net-dt/css/dataTables.dataTables.min.css";
 
 body {
     font-size: 12px;

--- a/css/spiders.css
+++ b/css/spiders.css
@@ -1,5 +1,5 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
-@import "datatables.net-dt/css/jquery.dataTables.min.css";
+@import "datatables.net-dt/css/dataTables.dataTables.min.css";
 
 body {
     font-size: 12px;
@@ -42,4 +42,10 @@ body {
 }
 .selector-div {
     display: inline-block;
+}
+
+.dt-length label {
+    /* Bootstrap's _reboot interferes here. Perhaps use DataTables' Bootstrap
+       styling instead? */
+    display: inline;
 }

--- a/css/wikidata.css
+++ b/css/wikidata.css
@@ -1,5 +1,5 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
-@import "datatables.net-dt/css/jquery.dataTables.min.css";
+@import "datatables.net-dt/css/dataTables.dataTables.min.css";
 
 body {
     font-size: 12px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@maplibre/maplibre-gl-geocoder": "^1.8.0",
         "bootstrap": "^5.0.0",
-        "datatables.net-dt": "^1.13.4",
+        "datatables.net-dt": "^2.3.2",
         "datatables.net-fixedcolumns": "^5.0.4",
         "jquery": "^3.7.1",
         "maplibre-gl": "^5.3.0",
@@ -613,22 +613,22 @@
       }
     },
     "node_modules/datatables.net": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.11.tgz",
-      "integrity": "sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.2.tgz",
+      "integrity": "sha512-31TzwIQM0+pr2ZOEOEH6dsHd/WSAl5GDDGPezOHPI3mM2NK4lcDyOoG8xXeWmSbVfbi852LNK5C84fpp4Q+qxg==",
       "license": "MIT",
       "dependencies": {
-        "jquery": "1.8 - 4"
+        "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-dt": {
-      "version": "1.13.11",
-      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-1.13.11.tgz",
-      "integrity": "sha512-4GpS4OFLwIMfhb5UdJh6bEnh0E52jIJOlx7KLKs1pSce/xpHjvcmucbUWNaEndQIpHXtIxmVPoqcDB0ZbiVB+A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-2.3.2.tgz",
+      "integrity": "sha512-2heAMe0AVqJ8nt9wE35ArLtL1zP7N7qnhM3u52bLcJfi4NStxyBsHScVggTHVQPj7r9O+qirAxox1Xcr+Bm4Dw==",
       "license": "MIT",
       "dependencies": {
-        "datatables.net": "1.13.11",
-        "jquery": "1.8 - 4"
+        "datatables.net": "2.3.2",
+        "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-fixedcolumns": {
@@ -638,15 +638,6 @@
       "license": "MIT",
       "dependencies": {
         "datatables.net": "^2",
-        "jquery": ">=1.7"
-      }
-    },
-    "node_modules/datatables.net-fixedcolumns/node_modules/datatables.net": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.2.tgz",
-      "integrity": "sha512-gfODIKE3gpgbVeZy2QGj2Dq9roO6hy00S+k1knklrqlMyAMrh1wt0Q6ryBUM7gU96U77ysbq8dYhxFdmcC/oPQ==",
-      "license": "MIT",
-      "dependencies": {
         "jquery": ">=1.7"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "build": "npm run build:map && npm run build:map:css && npm run build:builds:css && npm run build:builds && npm run build:spiders:css && npm run build:spiders && npm run build:wikidata:css && npm run build:wikidata && npm run build:preview:css && npm run build:preview"
   },
   "dependencies": {
-    "maplibre-gl": "^5.3.0",
     "@maplibre/maplibre-gl-geocoder": "^1.8.0",
-    "pmtiles": "^4.3.0",
-    "jquery": "^3.7.1",
     "bootstrap": "^5.0.0",
-    "datatables.net-dt": "^1.13.4",
-    "datatables.net-fixedcolumns": "^5.0.4"
+    "datatables.net-dt": "^2.3.2",
+    "datatables.net-fixedcolumns": "^5.0.4",
+    "jquery": "^3.7.1",
+    "maplibre-gl": "^5.3.0",
+    "pmtiles": "^4.3.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.2"

--- a/src/spiders.js
+++ b/src/spiders.js
@@ -120,7 +120,15 @@ async function fetchStatsForHistoryListEntry(entry) {
             [10, 15, 20, 25, 50, 75, 100, "All"],
         ],
         pageLength: parseFloat(URL_QUERY_PARAMS['page_length']) || 10,
-        dom: 'l<"selector-div">frtip',
+        layout: {
+            topStart: [
+                'pageLength',
+                { div: { className: 'selector-div' } },
+            ],
+            topEnd: 'search',
+            bottomStart: 'info',
+            bottomEnd: 'paging'
+        },
         order: [[2, 'desc']],
         search: {search: URL_QUERY_PARAMS['search'] || ''},
         columns: [

--- a/src/wikidata.js
+++ b/src/wikidata.js
@@ -71,7 +71,15 @@ function isInt(value) {
     let dataTable = $("#spider-table").DataTable({
         lengthMenu: [10, 15, 20, 25, 50, 75, 100],
         pageLength: 10,
-        dom: 'l<"insight-files">frtip',
+        layout: {
+            topStart: [
+                'pageLength',
+                { div: { className: 'insight-files' } },
+            ],
+            topEnd: 'search',
+            bottomStart: 'info',
+            bottomEnd: 'paging'
+        },
         order: [[1, 'desc']],
         columnDefs: [
             { className: 'dt-center', targets: [0,5,6,7] },


### PR DESCRIPTION
It renders the table five times faster for me (4.58 s → 936 ms), and that’s without me even attempting to eliminate all the calls to ‘innerHTML’.

Differences are minor: the ‘dom’ option is replaced with something more readable; the CSS is renamed; I add a workaround for a clash with bootstrap’s _reboot.