### PR TITLE
[spiders.html] Add "Open in JOSM" links

### DIFF
--- a/css/spiders.css
+++ b/css/spiders.css
@@ -49,7 +49,3 @@ body {
        styling instead? */
     display: inline;
 }
-
-.no-josm {
-	display: none;
-}

--- a/src/spiders.js
+++ b/src/spiders.js
@@ -215,7 +215,11 @@ async function fetchStatsForHistoryListEntry(entry) {
                     let linkData = data[i].toLocaleString("us-US")
 
                     if (linkUrl) {
-                        $('td:eq(' + i + ')', row).html('<a href ="' + linkUrl + '">' + linkData + '</a> <a href="http://127.0.0.1:8111/import?new_layer=true&download_policy=never&upload_policy=never&url=' + linkUrl + '" ' + (JOSM_AVAILABLE ? 'class="josm"' : 'class="no-josm" ') + 'target="_blank">J</a>');
+                        linkHtml = '<a href ="' + linkUrl + '">' + linkData + '</a>';
+                        if ((linkFormat === "geojson") && JOSM_AVAILABLE) {
+                            linkHtml += ' <a href="http://127.0.0.1:8111/import?new_layer=true&download_policy=never&upload_policy=never&url=' + linkUrl + '" target="_blank">J</a>';
+                        }
+                        $('td:eq(' + i + ')', row).html(linkHtml);
                     } else {
                         $('td:eq(' + i + ')', row).html(linkData);
                     }


### PR DESCRIPTION
When JOSM has "remote control" enabled (and load from url) it can auto load a url, saving the human from downloading and opening a file.

<img width="1298" height="753" alt="Screenshot From 2025-11-07 11-02-37" src="https://github.com/user-attachments/assets/d1ebe866-4919-44ca-bdbf-d406fc6a09f0" />

<img width="1920" height="543" alt="image" src="https://github.com/user-attachments/assets/7d68eb53-6a1a-48ee-8525-4aeea8be066e" />
